### PR TITLE
On Ubuntu and Debian the package is named proftpd-basic

### DIFF
--- a/proftpd/map.jinja
+++ b/proftpd/map.jinja
@@ -1,6 +1,6 @@
 {% set proftpd = salt['grains.filter_by']({
     'Ubuntu': {
-        'pkg': 'proftpd',
+        'pkg': 'proftpd-basic',
         'config': '/etc/proftpd/proftpd.conf',
         'sql_config': '/etc/proftpd/sql.conf',
         'modules_config': '/etc/proftpd/modules.conf',
@@ -9,7 +9,7 @@
         'service': 'proftpd',
     },
     'Debian': {
-        'pkg': 'proftpd',
+        'pkg': 'proftpd-basic',
         'config': '/etc/proftpd/proftpd.conf',
         'sql_config': '/etc/proftpd/sql.conf',
         'modules_config': '/etc/proftpd/modules.conf',


### PR DESCRIPTION
Hello,

a simple modification to use the correct package name on Debian and Ubuntu.